### PR TITLE
Fix cargo generate-lockfile invocation where needed

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -74,7 +74,7 @@ jobs:
               Write-Error "❌ ERROR: Expected version '$env:EXPECTED_VERSION' is not a valid semantic version."
               exit 1
           }
-
+          cargo generate-lockfile
           $pkgid = cargo pkgid --quiet
           if ($pkgid -match "#(.+)$") {
               $currentVersion = $matches[1]


### PR DESCRIPTION
Ensure that `cargo generate-lockfile` is called where necessary in CI/CD