### PR TITLE
Fix cargo command println and reput env var in build

### DIFF
--- a/wslpluginapi-sys/Cargo.toml
+++ b/wslpluginapi-sys/Cargo.toml
@@ -21,7 +21,6 @@ hooks-field-names = ["dep:struct-field-names-as-array"]
 tempfile = { version = "3.16", optional = true }
 bindgen = "0.71"
 cfg-if = "1.0"
-constcat = "0.6.0"
 
 
 [dependencies]

--- a/wslpluginapi-sys/Cargo.toml
+++ b/wslpluginapi-sys/Cargo.toml
@@ -21,7 +21,7 @@ hooks-field-names = ["dep:struct-field-names-as-array"]
 tempfile = { version = "3.16", optional = true }
 bindgen = "0.71"
 cfg-if = "1.0"
-
+constcat = "0.6"
 
 [dependencies]
 libc = "0.2"

--- a/wslpluginapi-sys/build/header_processing.rs
+++ b/wslpluginapi-sys/build/header_processing.rs
@@ -61,13 +61,13 @@ fn preprocess_header<P: AsRef<Path>>(
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     use std::{fs, io::Write, path::PathBuf};
 
-    use crate::WSL_PLUGIN_API_HEADER_FILE;
+    use crate::WSL_PLUGIN_API_HEADER_FILE_NAME;
 
     let content = fs::read_to_string(&header_path)?;
     let modified_content = content.replace("Windows.h", "windows.h");
 
     let out_dir: PathBuf = env::var("OUT_DIR")?.into();
-    let comp_h_file_path = out_dir.join(format!("unix_"{}, WSL_PLUGIN_API_HEADER_FILE_NAME));
+    let comp_h_file_path = out_dir.join(format!("unix_{}", WSL_PLUGIN_API_HEADER_FILE_NAME));
     fs::File::create(&comp_h_file_path)?.write_all(modified_content.as_bytes())?;
     println!("Using modified header file at: {:?}", &comp_h_file_path);
     Ok(comp_h_file_path)

--- a/wslpluginapi-sys/build/header_processing.rs
+++ b/wslpluginapi-sys/build/header_processing.rs
@@ -67,7 +67,7 @@ fn preprocess_header<P: AsRef<Path>>(
     let modified_content = content.replace("Windows.h", "windows.h");
 
     let out_dir: PathBuf = env::var("OUT_DIR")?.into();
-    let comp_h_file_path = out_dir.join("unix_".to_string() + WSL_PLUGIN_API_HEADER_FILE);
+    let comp_h_file_path = out_dir.join(format!("unix_"{}, WSL_PLUGIN_API_HEADER_FILE_NAME));
     fs::File::create(&comp_h_file_path)?.write_all(modified_content.as_bytes())?;
     println!("Using modified header file at: {:?}", &comp_h_file_path);
     Ok(comp_h_file_path)

--- a/wslpluginapi-sys/build/main.rs
+++ b/wslpluginapi-sys/build/main.rs
@@ -1,30 +1,33 @@
 extern crate bindgen;
 mod header_processing;
-use constcat::concat;
 use std::env;
 use std::path::PathBuf;
-const WSL_PLUGIN_API_FILE_NAME: &str = "WslPluginApi";
-const WSL_PLUGIN_API_HEADER_FILE: &str = concat!(WSL_PLUGIN_API_FILE_NAME, ".h");
+const WSL_PLUGIN_API_FILE_BASE_NAME: &str = "WslPluginApi";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=build.rs");
+    let [wsl_plugin_api_header_file_name, wsl_plugin_api_output_file_name] =
+        ["h", "rs"].map(|ext| String::from(WSL_PLUGIN_API_FILE_BASE_NAME) + "." + ext);
     let host = env::var("HOST")?;
     let target = env::var("TARGET")?;
     let out_path: PathBuf = env::var("OUT_DIR")?.into();
 
     let manifest_dir =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set"));
-    let header_file_path = manifest_dir.join(format!(
-        "third_party/Microsoft.WSL.PluginApi/include/{}",
-        WSL_PLUGIN_API_HEADER_FILE
-    ));
+    let header_file_path = manifest_dir
+        .join("third_party/Microsoft.WSL.PluginApi/include")
+        .join(&wsl_plugin_api_header_file_name);
+    println!("cargo:rerun-if-changed={}", header_file_path.display());
 
     if !header_file_path.exists() {
         return Err(format!("Header file does not exist: {:?}", header_file_path).into());
     }
-    print!("cargo:rerun-if-changed={}", header_file_path.display());
-    let out_file = out_path.join("bindings.rs");
+    let out_file = out_path.join(&wsl_plugin_api_output_file_name);
     let api_header = header_processing::process(header_file_path, host, target)?;
     api_header.write_to_file(&out_file)?;
+    println!(
+        "cargo:rustc-env=WSL_PLUGIN_API_BINDGEN_OUTPUT_FILE_PATH={}",
+        out_file.display()
+    );
     Ok(())
 }

--- a/wslpluginapi-sys/build/main.rs
+++ b/wslpluginapi-sys/build/main.rs
@@ -1,13 +1,14 @@
 extern crate bindgen;
 mod header_processing;
+use constcat::concat;
 use std::env;
 use std::path::PathBuf;
 const WSL_PLUGIN_API_FILE_BASE_NAME: &str = "WslPluginApi";
+const WSL_PLUGIN_API_HEADER_FILE_NAME: &str = concat!(WSL_PLUGIN_API_FILE_BASE_NAME, ".h");
+const WSL_PLUGIN_API_OUTPUT_FILE_NAME: &str = concat!(WSL_PLUGIN_API_FILE_BASE_NAME, ".rs");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=build.rs");
-    let [wsl_plugin_api_header_file_name, wsl_plugin_api_output_file_name] =
-        ["h", "rs"].map(|ext| String::from(WSL_PLUGIN_API_FILE_BASE_NAME) + "." + ext);
     let host = env::var("HOST")?;
     let target = env::var("TARGET")?;
     let out_path: PathBuf = env::var("OUT_DIR")?.into();
@@ -16,13 +17,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set"));
     let header_file_path = manifest_dir
         .join("third_party/Microsoft.WSL.PluginApi/include")
-        .join(&wsl_plugin_api_header_file_name);
+        .join(WSL_PLUGIN_API_HEADER_FILE_NAME);
     println!("cargo:rerun-if-changed={}", header_file_path.display());
 
     if !header_file_path.exists() {
         return Err(format!("Header file does not exist: {:?}", header_file_path).into());
     }
-    let out_file = out_path.join(&wsl_plugin_api_output_file_name);
+    let out_file = out_path.join(WSL_PLUGIN_API_OUTPUT_FILE_NAME);
     let api_header = header_processing::process(header_file_path, host, target)?;
     api_header.write_to_file(&out_file)?;
     println!(

--- a/wslpluginapi-sys/src/bindgen.rs
+++ b/wslpluginapi-sys/src/bindgen.rs
@@ -1,4 +1,4 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+include!(env!("WSL_PLUGIN_API_BINDGEN_OUTPUT_FILE_PATH"));

--- a/xtask/src/nuspec.rs
+++ b/xtask/src/nuspec.rs
@@ -16,10 +16,6 @@ pub struct Package {
 }
 
 impl Package {
-    pub fn new(metadata: Metadata) -> Self {
-        Self { metadata }
-    }
-
     pub fn from_reader<R: BufRead>(reader: R) -> Result<Self, DeError> {
         let package: Package = from_reader(reader)?;
         Ok(package)


### PR DESCRIPTION
- **Use xtask to download nuget package in order to avoid downloading on build task (#23)**
- **Fix duplicate build task in CI**
- **Fix xtask**
- **Fix xtask licence error by replacing xml dependency**
- **Fix cargo and reuse env var**
